### PR TITLE
fix: おすすめ商品が無い場合、おすすめ商品の項目を表示しない

### DIFF
--- a/src/components/pages/SweetsDetail/SweetsDetail.tsx
+++ b/src/components/pages/SweetsDetail/SweetsDetail.tsx
@@ -107,19 +107,21 @@ export const SweetsDetailPage: React.FC<Props> = ({ match, history }) => {
             </IonShopNameItem>
           </IonList>
 
-          <IonList>
-            <IonListHeader>おすすめ商品</IonListHeader>
-            <SquareImageList>
-              {recommendedSweetsIds.map(id => (
-                <SquareImage
-                  key={id}
-                  src={sweets[id].imagePath}
-                  alt={sweets[id].name}
-                  onClick={handleRecommendClick(id)}
-                />
-              ))}
-            </SquareImageList>
-          </IonList>
+          {recommendedSweetsIds.length > 0 && (
+            <IonList>
+              <IonListHeader>おすすめ商品</IonListHeader>
+              <SquareImageList>
+                {recommendedSweetsIds.map(id => (
+                  <SquareImage
+                    key={id}
+                    src={sweets[id].imagePath}
+                    alt={sweets[id].name}
+                    onClick={handleRecommendClick(id)}
+                  />
+                ))}
+              </SquareImageList>
+            </IonList>
+          )}
         </ContentUnderImage>
       </IonSweetsDetailContent>
     </IonPage>


### PR DESCRIPTION
## issue #18 
[![Image from Gyazo](https://i.gyazo.com/c5c859ad13a6f226407b0e4719f26a41.gif)](https://gyazo.com/c5c859ad13a6f226407b0e4719f26a41)