### PR TITLE
Merge pull request #39 from YTakahashii/fix/storeDetailTextStyle

### DIFF
--- a/src/components/pages/ShopDetail/ShopDetail.tsx
+++ b/src/components/pages/ShopDetail/ShopDetail.tsx
@@ -61,36 +61,48 @@ export const ShopDetailPage: React.FC<Props> = ({ match, history }) => {
 
           <IonShopDetailItem lines='none'>
             <IonIcon icon={call} size='small' slot='start'></IonIcon>
-            <IonLabel>{selectedShop.telephone}</IonLabel>
+            <IonLabel position='fixed'>電話番号</IonLabel>
+            <IonText>{selectedShop.telephone}</IonText>
           </IonShopDetailItem>
 
           <IonShopDetailItem lines='none'>
             <IonIcon icon={time} size='small' slot='start'></IonIcon>
-            <IonLabel>{selectedShop.openingHoursSpecification}</IonLabel>
+            <IonLabel position='fixed'>営業時間</IonLabel>
+            <IonText>{selectedShop.openingHoursSpecification}</IonText>
           </IonShopDetailItem>
 
           <IonShopDetailItem lines='none'>
             <IonIcon icon={calendar} size='small' slot='start'></IonIcon>
-            <IonLabel>{selectedShop.closed}</IonLabel>
+            <IonLabel position='fixed'>定休日</IonLabel>
+            <IonText>{selectedShop.closed}</IonText>
           </IonShopDetailItem>
 
           <IonShopDetailItem lines='none'>
             <IonSopDetaiFontawesomelIcon isMaterial={isMaterial()}>
               <i className='fas fa-parking'></i>
             </IonSopDetaiFontawesomelIcon>
-            <IonLabel>{selectedShop.parking}</IonLabel>
+            <IonLabel position='fixed'>駐車場</IonLabel>
+            <IonText>{selectedShop.parking}</IonText>
           </IonShopDetailItem>
 
           <IonShopDetailItem lines='none'>
             <IonIcon icon={restaurant} size='small' slot='start'></IonIcon>
-            <IonLabel>{selectedShop.eatin}</IonLabel>
+            <IonLabel position='fixed'>イートイン</IonLabel>
+            <IonText>{selectedShop.eatin}</IonText>
           </IonShopDetailItem>
 
           <IonShopDetailItem lines='none'>
             <IonIcon icon={link} size='small' slot='start'></IonIcon>
-            <a href={selectedShop.url} target='_blank' rel='noopener noreferrer'>
-              {selectedShop.url}
-            </a>
+            <IonLabel position='fixed'>公式サイト</IonLabel>
+            {selectedShop.url === 'なし' ? (
+              <IonText>なし</IonText>
+            ) : (
+              <IonText>
+                <a href={selectedShop.url} target='_blank' rel='noopener noreferrer'>
+                  {selectedShop.url}
+                </a>
+              </IonText>
+            )}
           </IonShopDetailItem>
 
           <IonList>

--- a/src/components/pages/ShopDetail/ShopDetail.tsx
+++ b/src/components/pages/ShopDetail/ShopDetail.tsx
@@ -62,7 +62,11 @@ export const ShopDetailPage: React.FC<Props> = ({ match, history }) => {
           <IonShopDetailItem lines='none'>
             <IonIcon icon={call} size='small' slot='start'></IonIcon>
             <IonLabel position='fixed'>電話番号</IonLabel>
-            <IonText>{selectedShop.telephone}</IonText>
+            <IonText>
+              <a href={`tel:${selectedShop.telephone}`} target='_blank' rel='noopener noreferrer'>
+                {selectedShop.telephone}
+              </a>
+            </IonText>
           </IonShopDetailItem>
 
           <IonShopDetailItem lines='none'>

--- a/src/components/pages/ShopDetail/ShopDetail.tsx
+++ b/src/components/pages/ShopDetail/ShopDetail.tsx
@@ -38,8 +38,8 @@ export const ShopDetailPage: React.FC<Props> = ({ match, history }) => {
   );
   const imgRef = useRef<HTMLImageElement>(null);
 
-  const getImgWidth = () => (imgRef.current ? imgRef.current.getBoundingClientRect().width : 'auto');
   const handleSweetsClick = (id: number) => () => history.push(`/sweets/${id}`);
+  const urlReg = /^(https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)$/; // eslint-disable-line no-useless-escape
 
   return (
     <IonPage>
@@ -98,14 +98,14 @@ export const ShopDetailPage: React.FC<Props> = ({ match, history }) => {
           <IonShopDetailItem lines='none'>
             <IonIcon icon={link} size='small' slot='start'></IonIcon>
             <IonLabel position='fixed'>公式サイト</IonLabel>
-            {selectedShop.url === 'なし' ? (
-              <IonText>なし</IonText>
-            ) : (
+            {selectedShop.url.match(urlReg) ? (
               <IonText>
                 <a href={selectedShop.url} target='_blank' rel='noopener noreferrer'>
                   {selectedShop.url}
                 </a>
               </IonText>
+            ) : (
+              <IonText>なし</IonText>
             )}
           </IonShopDetailItem>
 


### PR DESCRIPTION
issue #34 

- 店舗詳細画面の情報欄アイコン横に補助テキストを追加
  - 補助テキストは適当に決めちゃいました

- 店舗詳細画面の情報テキストのレイアウト微調整
  - 店舗詳細情報を`IonLabel`から`IonText`に変更
  - 端末が変わると`IonLabel`に`white-space: nowrap`が適用され、テキストが省略されてしまう問題
  - `IonText`だと省略されなかったのでこっちにした

- 店舗の公式サイトが無い場合はテキストにアンカーを付けない
  - 単純に該当項目が`なし`の場合とそうでない場合で評価した

ついでに
- 店舗の電話番号にアンカーをつけてワンタップで電話できるようにした


[![Image from Gyazo](https://i.gyazo.com/0503927a52490a49a96a00ef407ffd86.gif)](https://gyazo.com/0503927a52490a49a96a00ef407ffd86)

[![Image from Gyazo](https://i.gyazo.com/78183aa2e565e8b6127f383eb9584aa6.gif)](https://gyazo.com/78183aa2e565e8b6127f383eb9584aa6)