### PR TITLE
fix: iOSのみアニメーションを無効化

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -1,15 +1,6 @@
 import React, { useEffect } from 'react';
 import { Redirect, Route } from 'react-router-dom';
-import {
-  setupConfig,
-  IonApp,
-  IonIcon,
-  IonLabel,
-  IonRouterOutlet,
-  IonTabBar,
-  IonTabButton,
-  IonTabs,
-} from '@ionic/react';
+import { IonApp, IonIcon, IonLabel, IonRouterOutlet, IonTabBar, IonTabButton, IonTabs } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import { home, heart, map, search } from 'ionicons/icons';
 import { SweetsPage } from './components/pages/Sweets/Sweets';
@@ -22,10 +13,6 @@ import { useDispatch } from 'react-redux';
 import { loadData } from './actions/App/ActionCreator';
 import { scrollToTopSweetsListEvent } from './events/event';
 import { SearchBySmallCategoryPage } from './components/pages/SearchBySmallCategory/SearchBySmallCategory';
-
-setupConfig({
-  swipeBackEnabled: false,
-});
 
 export const AppRouter: React.FC = () => {
   const dispatch = useDispatch();

--- a/src/IonicConfig.ts
+++ b/src/IonicConfig.ts
@@ -1,0 +1,9 @@
+import { setupConfig } from '@ionic/react';
+import { isMaterial } from './utils/isMaterial';
+
+const animated = isMaterial(); // iOSのみアニメーションをオフにする
+
+setupConfig({
+  swipeBackEnabled: false,
+  animated,
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { ServiceWorkerUpdatePrompt } from './ServiceWorkerUpdatePrompt';
+import './IonicConfig';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 


### PR DESCRIPTION
## 概要
**What**
iOSのみアニメーションを無効化した

**Why**
iOSではスワイプバックするとアニメーションが2重で発生してしまうため

**懸念事項**
戻るアニメーションだけ無効化したほうが良いかも知れない
